### PR TITLE
Provide peername in responses

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
-elixir 1.11.3
+elixir 1.15.7-otp-26
+erlang 26.2.3

--- a/lib/stream/response.ex
+++ b/lib/stream/response.ex
@@ -19,23 +19,25 @@ defmodule Kadabra.Stream.Response do
       }
   """
 
-  defstruct [:id, :headers, :body, :status]
+  defstruct [:id, :headers, :body, :status, :peername]
 
   @type t :: %__MODULE__{
           id: non_neg_integer,
           headers: Keyword.t(),
           body: String.t(),
-          status: integer
+          status: integer,
+          peername: any() | nil
         }
 
   @doc false
-  @spec new(non_neg_integer, Keyword.t(), String.t()) :: t
-  def new(id, headers, body) do
+  @spec new(non_neg_integer, Keyword.t(), String.t(), any() | nil) :: t
+  def new(id, headers, body, peer_name \\ nil) do
     %__MODULE__{
       id: id,
       headers: headers,
       body: body,
-      status: get_status(headers)
+      status: get_status(headers),
+      peername: peer_name
     }
   end
 


### PR DESCRIPTION
This keeps track of the peername (remote IP/port) when creating a new Stream within a Connection and then provides the peername in the Response. This then allows Pigeon to include it in its response, so the ultimate client can see which actual remote IP address the request was sent to.