### PR TITLE
Improve robustness

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -9,6 +9,11 @@ defmodule Kadabra.Application do
       {Task.Supervisor, name: Kadabra.Tasks}
     ]
 
-    Supervisor.start_link(children, strategy: :one_for_one, name: :kadabra)
+    Supervisor.start_link(children,
+      strategy: :one_for_one,
+      max_restarts: 12,
+      max_seconds: 2,
+      name: :kadabra
+    )
   end
 end

--- a/lib/connection_pool.ex
+++ b/lib/connection_pool.ex
@@ -12,6 +12,7 @@ defmodule Kadabra.ConnectionPool do
         }
 
   alias Kadabra.Connection
+  require Logger
 
   @spec start_link(URI.t(), pid, Keyword.t()) :: {:ok, pid}
   def start_link(uri, pid, opts) do
@@ -95,6 +96,11 @@ defmodule Kadabra.ConnectionPool do
   end
 
   def handle_info({:EXIT, _pid, {:shutdown, :connection_error}}, state) do
+    {:stop, :shutdown, state}
+  end
+
+  def handle_info({:EXIT, _pid, reason}, state) do
+    Logger.info("ConnectionPool exited with reason: #{inspect(reason)}.")
     {:stop, :shutdown, state}
   end
 

--- a/lib/socket.ex
+++ b/lib/socket.ex
@@ -28,8 +28,8 @@ defmodule Kadabra.Socket do
     GenServer.call(pid, {:set_active, self()})
   end
 
-  def peername(pid) do
-    GenServer.call(pid, :peername)
+  def peername(pid, timeout_ms \\ 50) do
+    GenServer.call(pid, :peername, timeout_ms)
   end
 
   def start_link(uri, opts) do

--- a/lib/stream.ex
+++ b/lib/stream.ex
@@ -60,7 +60,7 @@ defmodule Kadabra.Stream do
       client: config.client,
       uri: config.uri,
       socket: config.socket,
-      peername: Socket.peername(config.socket),
+      peername: try_get_peername(config.socket),
       encoder: config.encoder,
       decoder: config.decoder,
       connection: self(),
@@ -344,4 +344,12 @@ defmodule Kadabra.Stream do
   end
 
   def code_change(_vsn, state, data, _extra), do: {:ok, state, data}
+
+  defp try_get_peername(socket) do
+    try do
+      Socket.peername(socket)
+    catch
+      :exit, {:timeout, _} -> nil
+    end
+  end
 end


### PR DESCRIPTION
This PR contains a few cleanups/fixes to address issues I've noticed while troubleshooting [STIL2-4452](https://tangotango.atlassian.net/browse/STIL2-4452).

* Set a short timeout on the call to `Socket.peername` and handle the timeout locally. I wanted to do this when I wrote the code, but I couldn't figure out how. It turns out you have to catch `:exit, term` (just catching `term` won't match) when calling `GenServer.call(server, message, timeout)`. Not getting the peername is no big deal and I don't want to hold up a request wait on it. It was also previously leading to timeout errors after 5 seconds (the default) which may have been exacerbating other issues (see below).

* Tighten the requirements for shutting down the whole application due to connection restarts. Instead of needing to exceed 3 restarts in 5 seconds, it now needs to exceed 12 restarts in 2 seconds. Hopefully this will prevent us from shutting down a whole node just because 4 connections happened to die around the same time.

* Prevent an issue that I still can't completely explain wherein killing a `ConnectionPool` (or any of the processes underneath it) would cause two processes to be restarted in its place. Adding a handler for other, previously unhandled EXIT messages and turning them into a normal `:shutdown` seemed to fix it.

[STIL2-4452]: https://tangotango.atlassian.net/browse/STIL2-4452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ